### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You no longer need to extend a view to set a custom behavior
 
 Carpaccio also come with a beautiful mapping engine !
 
-#Usage
+# Usage
 
 ```xml
 <com.github.florent37.carpaccio.Carpaccio
@@ -45,7 +45,7 @@ Carpaccio also come with a beautiful mapping engine !
 
 ![url](https://raw.githubusercontent.com/florent37/Carpaccio/master/screenshot/sample_crop.png)
 
-#Download
+# Download
 
 Add into your **build.gradle**
 
@@ -59,7 +59,7 @@ compile ('com.github.florent37:carpaccio:(lastest version)@aar'){
 
 ------------
 
-#DataBinding
+# DataBinding
 
 ```xml
 <TextView
@@ -92,7 +92,7 @@ carpaccio.mapObject("user",new User("florent", "www."));
 
 ------------
 
-##RecyclerView Mapping
+## RecyclerView Mapping
 
 You dreamed it, Carpaccio did it ! You can now bind a List with a RecyclerView !
 
@@ -166,7 +166,7 @@ carpaccio.mapObject("header", this.headerObject);
 
 ------------
 
-#ViewControllers
+# ViewControllers
 
 Carpaccio provide some awesome ViewControllers, you can use them directly into your project.
 [Read the Wiki to have a list of all provided viewControllers](https://github.com/florent37/Carpaccio/wiki)
@@ -195,7 +195,7 @@ TextViewController can set a custom font (from assets/fonts/) to a TextView and 
 
 ------------
 
-##ImageViewController
+## ImageViewController
 
 ```xml
 <com.github.florent37.carpaccio.Carpaccio
@@ -259,19 +259,19 @@ And some awesome customisations
       " />
 ```
 
-#Community
+# Community
 
 Looking for contributors, feel free to fork !
 
 Tell me if you're using my library in your application, I'll share it in this README
 
-#Dependencies
+# Dependencies
 
 * [Picasso][picasso] (from Square)
 * [KenBurnsView][kenburnsview] (from flavioarfaria)
 * [Android-Observablescrollview][android-observablescrollview] (from ksoichiro)
 
-#Credits
+# Credits
 
 Author: Florent Champigny
 www.florentchampigny.com/


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
